### PR TITLE
PLL integration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Polylang integration is run on the 'wp_loaded' hook. This prevents various warnings by allowing PLL to fully load itself before running integrations.
+
 ## 0.1.2 - 2020-05-28
 
 ### Fixed

--- a/plugin.php
+++ b/plugin.php
@@ -66,7 +66,7 @@ class Plugin {
         Settings::init( self::$plugin_data );
 
         // Initialize plugin controllers after plugins are loaded.
-        add_action( 'plugins_loaded', function() {
+        add_action( 'wp_loaded', function() {
             LocalizationController::init();
         } );
 

--- a/src/Localization/Polylang.php
+++ b/src/Localization/Polylang.php
@@ -60,12 +60,6 @@ class Polylang {
 
                 // Check if media duplication is on.
                 if ( $polylang->model->options['media_support'] && $polylang->options['media']['duplicate'] ?? 0 ) {
-
-                    // Needed for PLL_Admin_Advanced_Media.
-                    $polylang->filters_media = new \PLL_Admin_Filters_Media( $polylang );
-
-                    // Activates media duplication.
-                    $polylang->oopi_advanced_media = new \PLL_Admin_Advanced_Media( $polylang );
                     // Hook into media duplication so we can add attachment_id meta.
                     // add_action( 'pll_translate_media', array( __CLASS__, 'get_attachment_post_ids' ), 11, 3 );
                 }


### PR DESCRIPTION
### Fixed
- Polylang integration is run on the 'wp_loaded' hook. This prevents various warnings by allowing PLL to fully load itself before running integrations.