### PR TITLE
Changes get_plugin_data to get_file_data

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -59,7 +59,7 @@ class Plugin {
         }
 
         // Set the plugin version.
-        $plugin_data       = get_plugin_data( __FILE__, false, false );
+        $plugin_data       = get_file_data( __FILE__, [ 'Version' => 'Version' ], 'plugin' );
         self::$plugin_data = wp_parse_args( $plugin_data, self::$plugin_data );
 
         // Set the basic settings.


### PR DESCRIPTION
Using `get_plugin_data()` made OOPI barf (tested on /wp-admin page and `wp` cli tool and WP version 5.4.2).

```
root@416358394efa:/var/www/project# wp plugin
PHP Fatal error:  Uncaught Error: Call to undefined function Geniem\Oopi\get_plugin_data() in /var/www/project/web/app/plugins/wp-oopi/plugin.php:62
Stack trace:
#0 /var/www/project/web/app/plugins/wp-oopi/plugin.php(79): Geniem\Oopi\Plugin::init()
#1 /var/www/project/web/wp/wp-settings.php(371): include_once('/var/www/projec...')
#2 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1209): require('/var/www/projec...')
#3 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1130): WP_CLI\Runner->load_wordpress()
#4 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#5 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#6 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#7 phar:///usr/local/bin/wp-cli/php/boot-phar.php(11): include('phar:///usr/loc...')
#8 /usr/local/bin/wp-cli(4): include('phar:///usr/loc...')
#9 {main}
  thrown in /var/www/project/web/app/plugins/wp-oopi/plugin.php on line 62
Error: Sivustollasi on ollut kriittinen virhe.Lue lisää virheiden löytämisestä WordPressissä. Sivustollasi on ollut kriittinen virhe.
```

Changed `get_plugin_data()` to `get_file_data()` per @villesiltala advice to
follow wp-plugin-boilerplate example: https://github.com/devgeniem/wp-plugin-boilerplate/blob/master/plugin.php#L25