### PR TITLE
Localization & term importing updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Localize all terms in translated taxonomies if i18n data is added for the Post object.
+- New typed classes for taxonomy term and language data.
+  - Geniem\Oopi\Term
+  - Geniem\Oopi\Language
+- Localize newly created terms if language data is added for the Post object.
 - Try to prevent the post name from getting a number suffix
   when translating posts with Polylang by updating the post data
   with the original post name after setting the language.
 - Add a language agnostic term finding method to Storage class. Use it to find terms by slug.
 
 ### Changed
-- Allow i18n data to be set as an associative array or an object.
+- Allow language data to be set as an associative array or an object. Map data into a Geniem\Oopi\Language object.
+- Simplify Oopi id handling in get_post_id_by_oopi_id().
+- The `i18n` is now deprecated, but still functioning if set. The data is mapped into a Geniem\Oopi\Language object.
+- Taxonomy term data must contain an `oopi_id` for identification.
 
 ## [0.2.0] - 2020-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Localize newly created terms if i18n data is added for the Post object.
+- Localize all terms in translated taxonomies if i18n data is added for the Post object.
 - Try to prevent the post name from getting a number suffix
   when translating posts with Polylang by updating the post data
   with the original post name after setting the language.
+- Add a language agnostic term finding method to Storage class. Use it to find terms by slug.
 
 ### Changed
 - Allow i18n data to be set as an associative array or an object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Localize newly created terms if i18n data is added for the Post object.
+- Try to prevent the post name from getting a number suffix
+  when translating posts with Polylang by updating the post data
+  with the original post name after setting the language.
+
+### Changed
+- Allow i18n data to be set as an associative array or an object.
+
 ## [0.2.0] - 2020-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ The first step in the import process is to set the data for the importer. This f
     - `description` *(string) (Optional)* The file description text.
   - `meta` *(object) (Optional)* An object where all the keys correspond to meta keys and values correspond to meta values.
   - `taxonomies` *(array) (Optional)* An array containing either-or:
-    - array/object with key-value pairs:
+    - *(Geniem\Oopi\Term)* Oopi Term object.
+      - _If the Oopi term holds a WP_Term object, importing will override existing term data._
+    - *(array|object)* Raw data will be mapped into a Term object. 
+      - `oopi_id` *(string) (Required)* All terms must contain an id. 
       - `slug` *(string) (Required)* The taxonomy term slug.
       - `name` *(string) (Required)* The taxonomy term display name.
       - `taxonomy` *(string) (Required)* The taxonomy name, for example `category`.
-    - [WP Term](https://developer.wordpress.org/reference/classes/wp_term/) instances 
   - `acf` *(array) (Optional)* An array of Advanced Custom Fields data objects containing:
     - `type` *(string) (Required)* The ACF field type ([types](https://www.advancedcustomfields.com/resources/#field-types)).
     - `key` *(string) (Required)* The ACF field key. This must be the unique key defined for the field.
     - `value` *(mixed) (Required)* The data value matching the field type specifications.
-  - `i18n` *(object|array) (Optional)* Custom localization information is stored in the property. It must contain an object/array with the following properties/keys:
-    - `locale` *(string) (Required)* The language code string, for example `fi`.
-    - `master` *(string|object) (Required)* A `oopi_id` value to be used to fetch a default language post or an array containing a `query_key` value. This is used to link the post as a translation.
+  - `language` *(Geniem\Oopi\Language|object|array) (Optional)* Localization information in an Oopi Language object or raw data. Raw data will be converted into a Language instance.
 
 #### Example usage
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The first step in the import process is to set the data for the importer. This f
     - `type` *(string) (Required)* The ACF field type ([types](https://www.advancedcustomfields.com/resources/#field-types)).
     - `key` *(string) (Required)* The ACF field key. This must be the unique key defined for the field.
     - `value` *(mixed) (Required)* The data value matching the field type specifications.
-  - `i18n` *(object) (Optional)* Custom localization information is stored in the property. It must contain an object with the following properties:
+  - `i18n` *(object|array) (Optional)* Custom localization information is stored in the property. It must contain an object/array with the following properties/keys:
     - `locale` *(string) (Required)* The language code string, for example `fi`.
     - `master` *(string|object) (Required)* A `oopi_id` value to be used to fetch a default language post or an array containing a `query_key` value. This is used to link the post as a translation.
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Oopi
  * Plugin URI:  https://github.com/devgeniem/wp-oopi
  * Description: Oopi is an object-oriented developer friendly WordPress importer.
- * Version:     0.1.1
+ * Version:     0.3.0
  * Author:      Geniem
  * Author URI:  http://www.github.com/devgeniem
  * License:     GPL3

--- a/src/Language.php
+++ b/src/Language.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * A class for defining an object's language
+ * and the related master translation.
+ */
+
+namespace Geniem\Oopi;
+
+use Geniem\Oopi\Traits\PropertyBinder;
+
+/**
+ * Class Language
+ *
+ * @package Geniem\Oopi
+ */
+class Language {
+
+    /**
+     * Add the set_data() binding method.
+     */
+    use PropertyBinder;
+
+    /**
+     * The locale.
+     *
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * The master id tells Oopi which
+     * object is the master (default) translation.
+     *
+     * @var string
+     */
+    protected $master_oopi_id;
+
+    /**
+     * Language constructor.
+     *
+     * @param string $locale         The locale.
+     * @param string $master_oopi_id The master object's Oopi id.
+     */
+    public function __construct( ?string $locale = '', ?string $master_oopi_id = '' ) {
+        $this->locale         = $locale;
+        $this->master_oopi_id = $master_oopi_id;
+    }
+
+    /**
+     * Get the locale.
+     *
+     * @return string
+     */
+    public function get_locale() : string {
+        return $this->locale;
+    }
+
+    /**
+     * Set the locale.
+     *
+     * @param string $locale The locale.
+     *
+     * @return Language Return self to enable chaining.
+     */
+    public function set_locale( ?string $locale ) : Language {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * Get the master_oopi_id.
+     *
+     * @return string
+     */
+    public function get_master_oopi_id() : string {
+        return $this->master_oopi_id;
+    }
+
+    /**
+     * Set the master_oopi_id.
+     *
+     * @param string $master_oopi_id The master_oopi_id.
+     *
+     * @return Language Return self to enable chaining.
+     */
+    public function set_master_oopi_id( ?string $master_oopi_id ) : Language {
+        $this->master_oopi_id = $master_oopi_id;
+
+        return $this;
+    }
+
+}

--- a/src/Localization/Controller.php
+++ b/src/Localization/Controller.php
@@ -7,6 +7,7 @@ namespace Geniem\Oopi\Localization;
 
 // Classes
 use Geniem\Oopi\Post as Post;
+use Geniem\Oopi\Util;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -27,15 +28,14 @@ class Controller {
     }
 
     /**
-     * Saves plugin with your installed WordPress translation plugin.
-     * The actual locale saving is happening in Plugin specific classes
-     * Geniem\Oopi\Localization\Polylang and Geniem\Oopi\Localization\WPML
+     * Saves language data with your installed WordPress translation plugin.
+     * The actual language saving is done in corresponding plugin classes.
      *
      * @param Post $post Instance of the Post class.
      *
      * @return boolean
      */
-    public static function save_locale( &$post ) {
+    public static function save_language( &$post ) {
 
         // Check which translation plugin should be used
         $activated_i18n_plugin = self::get_activated_i18n_plugin( $post );
@@ -49,6 +49,38 @@ class Controller {
         if ( $activated_i18n_plugin === 'polylang' ) {
             Polylang::save_pll_locale( $post );
         }
+    }
+
+    /**
+     * Saves WP term language data with your installed WordPress translation plugin.
+     * The actual language saving is done in corresponding plugin classes.
+     *
+     * @param int  $term_id The WP term id.
+     * @param Post $post    The Oopi post.
+     *
+     * @return boolean
+     */
+    public static function set_term_language( int $term_id, Post $post ) {
+
+        // Check which translation plugin should be used
+        $activated_i18n_plugin = self::get_activated_i18n_plugin( $post );
+
+        // If no translation plugin was detected.
+        if ( $activated_i18n_plugin === false ) {
+            return false;
+        }
+
+        // If Polylang is activated use Polylang.
+        if ( $activated_i18n_plugin === 'polylang' ) {
+            $i18n   = $post->get_i18n();
+            $locale = Util::get_prop( $i18n, 'locale', '' );
+
+            Polylang::set_term_language( $term_id, $locale );
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Localization/Controller.php
+++ b/src/Localization/Controller.php
@@ -7,6 +7,7 @@ namespace Geniem\Oopi\Localization;
 
 // Classes
 use Geniem\Oopi\Post as Post;
+use Geniem\Oopi\Term;
 use Geniem\Oopi\Util;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -55,12 +56,12 @@ class Controller {
      * Saves WP term language data with your installed WordPress translation plugin.
      * The actual language saving is done in corresponding plugin classes.
      *
-     * @param int  $term_id The WP term id.
-     * @param Post $post    The Oopi post.
+     * @param Term $term The Oopi term.
+     * @param Post $post The Oopi post.
      *
      * @return boolean
      */
-    public static function set_term_language( int $term_id, Post $post ) {
+    public static function set_term_language( Term $term, Post $post ) {
 
         // Check which translation plugin should be used
         $activated_i18n_plugin = self::get_activated_i18n_plugin( $post );
@@ -72,10 +73,8 @@ class Controller {
 
         // If Polylang is activated use Polylang.
         if ( $activated_i18n_plugin === 'polylang' ) {
-            $i18n   = $post->get_i18n();
-            $locale = Util::get_prop( $i18n, 'locale', '' );
 
-            Polylang::set_term_language( $term_id, $locale );
+            Polylang::set_term_language( $term, $post );
 
             return true;
         }
@@ -92,7 +91,7 @@ class Controller {
      *
      * @return string|boolean
      */
-    public static function get_activated_i18n_plugin( &$post ) {
+    public static function get_activated_i18n_plugin( $post ) {
 
         // Checks if Polylang is installed and activated
         $polylang_activated = function_exists( 'PLL' );

--- a/src/Localization/Polylang.php
+++ b/src/Localization/Polylang.php
@@ -148,7 +148,7 @@ class Polylang {
             ) {
                 wp_update_post(
                     [
-                        'ID'        => $post,
+                        'ID'        => $post->get_post_id(),
                         'post_name' => $post->get_post_name(),
                     ]
                 );

--- a/src/Localization/Polylang.php
+++ b/src/Localization/Polylang.php
@@ -128,15 +128,23 @@ class Polylang {
 
         // Get needed variables
         $post_id = $post->get_post_id();
+        $wp_post = get_post( $post_id );
         $i18n    = $post->get_i18n();
-        $locale  = Util::get_prop( $i18n, 'locale' );
+        $locale  = Util::get_prop( $i18n, 'locale', false );
         $master  = Util::get_prop( $i18n, 'master', false );
 
-        // If pll information is in wrong format
-        if ( is_array( $i18n ) ) {
+        if ( $locale && $master ) {
 
             // Set post locale.
             \pll_set_post_language( $post_id, $locale );
+
+            if ( $post->get_post_name() !== $wp_post->post_name ) {
+                // Update post name to allow PLL to handle unique slugs.
+                wp_update_post( [
+                    'ID'        => $post,
+                    'post_name' => $post->get_post_name(),
+                ] );
+            }
 
             // Run only if master exists
             if ( $master ) {
@@ -181,9 +189,21 @@ class Polylang {
             $post->set_error(
                 'pll',
                 $i18n,
-                __( 'Post does not have pll information in right format.', 'oopi' )
+                __( 'i18n information is set, but it is missing data.', 'oopi' )
             );
         }
+    }
+
+    /**
+     * Sets the term language.
+     *
+     * @param int    $term_id  The WP term id.
+     * @param string $language The language slug.
+     *
+     * @return void
+     */
+    public static function set_term_language( int $term_id, string $language ) {
+        pll_set_term_language( $term_id, $language );
     }
 
     /**

--- a/src/Localization/Polylang.php
+++ b/src/Localization/Polylang.php
@@ -140,10 +140,12 @@ class Polylang {
 
             if ( $post->get_post_name() !== $wp_post->post_name ) {
                 // Update post name to allow PLL to handle unique slugs.
-                wp_update_post( [
-                    'ID'        => $post,
-                    'post_name' => $post->get_post_name(),
-                ] );
+                wp_update_post(
+                    [
+                        'ID'        => $post,
+                        'post_name' => $post->get_post_name(),
+                    ]
+                );
             }
 
             // Run only if master exists
@@ -168,19 +170,19 @@ class Polylang {
                     // Set the link for translations if a matching post was found.
                     if ( $master_post_id ) {
 
-                            // Get current translation.
-                            $current_translations = \pll_get_post_translations( $master_post_id );
+                        // Get current translation.
+                        $current_translations = \pll_get_post_translations( $master_post_id );
 
-                            // Set up new translations.
-                            $new_translations = [
-                                'post_id' => $master_post_id,
-                                $locale   => $post_id,
-                            ];
+                        // Set up new translations.
+                        $new_translations = [
+                            'post_id' => $master_post_id,
+                            $locale   => $post_id,
+                        ];
 
-                            $parsed_args = \wp_parse_args( $new_translations, $current_translations );
+                        $parsed_args = \wp_parse_args( $new_translations, $current_translations );
 
-                            // Add and link translation.
-                            \pll_save_post_translations( $parsed_args );
+                        // Add and link translation.
+                        \pll_save_post_translations( $parsed_args );
                     }
                 }
             }
@@ -203,6 +205,18 @@ class Polylang {
      * @return void
      */
     public static function set_term_language( int $term_id, string $language ) {
+        $term = get_term( $term_id );
+
+        // Bail if no term was found or the taxonomy is not translated.
+        if ( ! $term instanceof \WP_Term || ! pll_is_translated_taxonomy( $term->taxonomy ) ) {
+            return;
+        }
+
+        if ( empty( $locale ) ) {
+            // Set the default language if no language was set.
+            $language = pll_default_language();
+        }
+
         pll_set_term_language( $term_id, $language );
     }
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -521,7 +521,7 @@ class Post {
         foreach ( $tax_array as $term ) {
             if ( ! $term instanceof Term ) {
                 $oopi_id = Util::get_prop( $term, 'oopi_id', '' );
-                $term    = ( new Term( $oopi_id ) )->set_data( $oopi_id );
+                $term    = ( new Term( $oopi_id ) )->set_data( $term );
             }
             $this->taxonomies[] = apply_filters( 'oopi_taxonomy_term', $term );
         }

--- a/src/Post.php
+++ b/src/Post.php
@@ -140,6 +140,15 @@ class Post {
     }
 
     /**
+     * Getter for the post name in the set post data.
+     *
+     * @return string
+     */
+    public function get_post_name() {
+        return $this->post->post_name ?? '';
+    }
+
+    /**
      * Getter for ig_id
      *
      * @return string
@@ -273,7 +282,7 @@ class Post {
         }
 
         // If post object has i18n object property set post language
-        if ( isset( $raw_post->i18n ) && is_array( $raw_post->i18n ) ) {
+        if ( isset( $raw_post->i18n ) ) {
             $this->set_i18n( $raw_post->i18n );
         }
     }
@@ -573,20 +582,12 @@ class Post {
             return;
         }
 
-        // Check if data is an array.
-        if ( ! is_array( $i18n ) ) {
-            // @codingStandardsIgnoreStart
-            $err = __( 'Error in the i18n data. The locale data must be passed in an associative array.', 'oopi' );
-            // @codingStandardsIgnoreEnd
-            $this->set_error( 'i18n', $i18n, $err );
-            return;
-        }
-
         // Check if locale is set and in the current installation.
-        if ( ! isset( $i18n['locale'] ) ) {
+        if ( ! Util::get_prop( $i18n, 'locale' ) ) {
             $err = __( 'Error in the polylang data. The locale is not set.', 'oopi' );
             $this->set_error( 'i18n', $i18n, $err );
-        } elseif ( ! in_array( $i18n['locale'], Polylang::language_list(), true ) ) {
+        }
+        elseif ( ! in_array( Util::get_prop( $i18n, 'locale' ), Polylang::language_list(), true ) ) {
             // @codingStandardsIgnoreStart
             $err = __( 'Error in the polylang data. The locale doesn\'t exist in the current WP installation', 'oopi' );
             // @codingStandardsIgnoreEnd
@@ -594,8 +595,9 @@ class Post {
         }
 
         // If a master post is set for the current post, check its validity.
-        if ( isset( $i18n['master'] ) ) {
-            if ( Util::is_query_id( $i18n['master']['query_key'] ?? '' ) === false ) {
+        $master = Util::get_prop( $i18n, 'master', false );
+        if ( $master ) {
+            if ( Util::is_query_id( Util::get_prop( $master, 'query_key', '' ) ) === false ) {
                 $err = __( 'Error in the i18n data. The master query id is missing or invalid.', 'oopi' );
                 $this->set_error( 'i18n', $i18n, $err );
             }
@@ -672,7 +674,7 @@ class Post {
 
         // Save localization data.
         if ( ! empty( $this->i18n ) ) {
-            Localization\Controller::save_locale( $this );
+            Localization\Controller::save_language( $this );
         }
 
         // Save attachments.

--- a/src/Post.php
+++ b/src/Post.php
@@ -8,6 +8,7 @@ namespace Geniem\Oopi;
 use Geniem\Oopi\Exception\PostException as PostException;
 use Geniem\Oopi\Localization\Polylang as Polylang;
 use WP_Post;
+use WP_Term;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -66,15 +67,24 @@ class Post {
     protected $meta = [];
 
     /**
-     * Taxonomies in a multidimensional associative array.
+     * Oopi Term objects in an array.
      *
      * @see $this->set_taxonomies() For description.
-     * @var array
+     * @var Term[]
      */
     protected $taxonomies = [];
 
     /**
+     * The language data.
+     *
+     * @var Language
+     */
+    protected $language;
+
+    /**
      * An array for locale data.
+     *
+     * @deprecated Use $language instead.
      *
      * @var array
      */
@@ -145,7 +155,9 @@ class Post {
      * @return string
      */
     public function get_post_name() {
-        return $this->post->post_name ?? '';
+        $post_name = $this->post->post_name ?? '';
+
+        return $post_name;
     }
 
     /**
@@ -236,7 +248,8 @@ class Post {
             // @codingStandardsIgnoreStart
             $this->set_error( 'id', 'oopi_id', __( 'A unique id must be set for the Post constructor.', 'oopi' ) );
             // @codingStandardsIgnoreEnd
-        } else {
+        }
+        else {
             // Set the Importer id.
             $this->oopi_id = $oopi_id;
             // Fetch the WP post id, if it exists.
@@ -281,7 +294,12 @@ class Post {
             $this->set_acf( $raw_post->acf );
         }
 
-        // If post object has i18n object property set post language
+        // If post object has a language object property, set post language.
+        if ( isset( $raw_post->language ) ) {
+            $this->set_language( $raw_post->language );
+        }
+
+        // @deprecated: If post object has i18n object property, set post language
         if ( isset( $raw_post->i18n ) ) {
             $this->set_i18n( $raw_post->i18n );
         }
@@ -299,7 +317,8 @@ class Post {
             foreach ( get_object_vars( $post_obj ) as $attr => $value ) {
                 $this->post->{$attr} = $value;
             }
-        } else {
+        }
+        else {
             // Set the post object.
             $this->post    = new \WP_Post( $post_obj );
             $this->post_id = null;
@@ -379,20 +398,18 @@ class Post {
                 // Check if parent exists.
                 $parent_post_id = Storage::get_post_id_by_oopi_id( $parent_id );
                 if ( $parent_post_id === false ) {
-                    // @codingStandardsIgnoreStart
-                    $err = __( 'Error in the "post_parent" column. The queried post parent was not found.', 'oopi' );
-                    // @codingStandardsIgnoreEnd
+                    $err = __( 'Error in the "post_parent" column. The queried post parent was not found.', 'oopi' ); // phpcs:ignore
                     $this->set_error( $err_scope, 'menu_order', $err );
-                } else {
+                }
+                else {
                     // Set parent post id.
                     $post_obj->post_parent = $parent_post_id;
                 }
-            } else {
+            }
+            else {
                 // The parent is a WP post id.
                 if ( \get_post( $parent_id ) === null ) {
-                    // @codingStandardsIgnoreStart
-                    $err = __( 'Error in the "post_parent" column. The parent id did not match any post.', 'oopi' );
-                    // @codingStandardsIgnoreEnd
+                    $err = __( 'Error in the "post_parent" column. The parent id did not match any post.', 'oopi' ); // phpcs:ignore
                     $this->set_error( $err_scope, 'menu_order', $err );
                 }
             }
@@ -410,9 +427,7 @@ class Post {
         if ( isset( $post_obj->post_type ) ) {
             $post_types = get_post_types();
             if ( ! array_key_exists( $post_obj->post_type, $post_types ) ) {
-                // @codingStandardsIgnoreStart
-                $err = __( 'Error in the "post_type" column. The value does not match a registered post type.', 'oopi' );
-                // @codingStandardsIgnoreEnd
+                $err = __( 'Error in the "post_type" column. The value does not match a registered post type.', 'oopi' ); // phpcs:ignore
                 $this->set_error( $err_scope, 'post_type', $err );
             }
         }
@@ -428,17 +443,21 @@ class Post {
     public function validate_date( $date_string = '', $col_name = '', $err_scope = '' ) {
         $valid = \DateTime::createFromFormat( 'Y-m-d H:i:s', $date_string );
         if ( ! $valid ) {
-            // @codingStandardsIgnoreStart
-            $err = __( "Error in the \"$col_name\" column. The value is not a valid datetime string.", 'oopi' );
-            // @codingStandardsIgnoreEnd
+            $err = sprintf(
+                // translators: %s stands for the column name.
+                __( 'Error in the %s column. The value is not a valid datetime string.', 'oopi' ),
+                $col_name
+            );
             $this->set_error( $err_scope, $col_name, $err );
         }
     }
 
 
     /**
-     * @todo doc / validation?
-     * @param [type] $attachments [description]
+     * Set attachment data.
+     *
+     * @todo validation?
+     * @param array $attachments Attachment objects|arrays.
      */
     public function set_attachments( $attachments ) {
         $this->attachments = $attachments;
@@ -454,7 +473,7 @@ class Post {
         $this->meta = (array) $meta_data;
         // Filter values before validating.
         foreach ( $this->meta as $key => $value ) {
-            $this->meta[ $key ] = apply_filters( "oopi_meta_value_{$key}", $value );
+            $this->meta[ $key ] = apply_filters( "oopi_meta_value_$key", $value );
         }
 
         $this->validate_meta( $this->meta );
@@ -475,26 +494,36 @@ class Post {
 
     /**
      * Set the taxonomies of the post.
-     * The taxonomies must be passed as an associative array
-     * where the key is the taxonomy slug and values are associative array
-     * with the name and the slug of the taxonomy term.
-     * Example:
+     *
+     * Example of setting a category as a Geniem\Oopi\Term object:
+     *     $term = ( new Geniem\Oopi\Term( 'external_id_123' ) )
+     *         ->set_name( 'My category' )
+     *         ->set_slug( 'my-category' )
+     *         ->set_taxonomy( 'cateogory' );
+     *     $tax_array = [
+     *         $term
+     *     ];
+     *
+     * Example of setting a category as raw data:
      *      $tax_array = [
-     *          'category' => [
-     *              [
-     *                  'name' => 'My category',
-     *                  'slug' => 'my-category',
-     *              ]
+     *          [
+     *              'taxonomy => 'category',
+     *              'name'    => 'My category',
+     *              'slug'    => 'my-category',
+     *              'oopi_id' => 'external_id_123',
+     *          ],
      *      ];
      *
      * @param array $tax_array The taxonomy data.
      */
-    public function set_taxonomies( $tax_array = [] ) {
-        // Force type to array.
-        $this->taxonomies = (array) $tax_array;
+    public function set_taxonomies( ?array $tax_array = [] ) {
         // Filter values before validating.
-        foreach ( $this->taxonomies as $key => $term ) {
-            $this->taxonomies[ $key ] = apply_filters( "oopi_taxonomy_term", $term );
+        foreach ( $tax_array as $term ) {
+            if ( ! $term instanceof Term ) {
+                $oopi_id = Util::get_prop( $term, 'oopi_id', '' );
+                $term    = ( new Term( $oopi_id ) )->set_data( $oopi_id );
+            }
+            $this->taxonomies[] = apply_filters( 'oopi_taxonomy_term', $term );
         }
         $this->validate_taxonomies( $this->taxonomies );
     }
@@ -502,13 +531,11 @@ class Post {
     /**
      * Validate the taxonomy array.
      *
-     * @param array $taxonomies The set taxonomies for the post.
+     * @param Term[] $taxonomies The set taxonomies for the post.
      */
     public function validate_taxonomies( $taxonomies ) {
         if ( ! is_array( $taxonomies ) ) {
-            // @codingStandardsIgnoreStart
-            $err = __( "Error in the taxonomies. Taxonomies must be passed in an associative array.", 'oopi' );
-            // @codingStandardsIgnoreEnd
+            $err = __( 'Error in the taxonomies. Taxonomies must be passed in an array.', 'oopi' ); // phpcs:ignore
             $this->set_error( 'taxonomy', $taxonomies, $err );
             return;
         }
@@ -517,13 +544,18 @@ class Post {
         $registered_taxonomies = \get_taxonomies();
         foreach ( $taxonomies as $term ) {
             if (
-                empty( Util::get_prop( $term, 'taxonomy' ) ) ||
-                ! in_array( Util::get_prop( $term, 'taxonomy' ), $registered_taxonomies, true )
+                empty( $term->get_taxonomy() ) ||
+                ! in_array( $term->get_taxonomy(), $registered_taxonomies, true )
             ) {
-                // @codingStandardsIgnoreStart
-                $tax = Util::get_prop( $term, 'taxonomy' );
-                $err = __( "Error in the \"$tax\" taxonomy. The taxonomy is not registerd.", 'oopi' );
-                // @codingStandardsIgnoreEnd
+                $err = sprintf(
+                    // translators: %s stands for the taxonomy slug.
+                    __( 'Error in the %s taxonomy. The taxonomy is not registerd.', 'oopi' ),
+                    $term->get_taxonomy()
+                );
+                $this->set_error( 'taxonomy', $term, $err );
+            }
+            if ( empty( $term->get_oopi_id() ) ) {
+                $err = __( 'Error in a term. Required `oopi_id` property not set.', 'oopi' );
                 $this->set_error( 'taxonomy', $term, $err );
             }
             apply_filters( 'oopi_validate_taxonomies', $taxonomies );
@@ -541,7 +573,7 @@ class Post {
         // Filter values before validating.
         /* @todo filtering (by name, not $key?)
         foreach ( $this->acf as $key => $value ) {
-            $this->acf[$key] = apply_filters( "oopi_acf_value_{$key}", $value );
+            $this->acf[$key] = apply_filters( "oopi_acf_value_$key", $value );
         }
         */
         $this->validate_acf( $this->acf );
@@ -561,13 +593,48 @@ class Post {
     }
 
     /**
+     * Get the language.
+     *
+     * @return Language
+     */
+    public function get_language() : Language {
+        return $this->language;
+    }
+
+    /**
+     * Sets the post's language data.
+     *
+     * @param Language|array|object $language The language data.
+     */
+    public function set_language( $language ) {
+        if ( ! $language instanceof Language ) {
+            $this->language = ( new Language() )->set_data( $language );
+        }
+        else {
+            $this->language = $language;
+        }
+        // TODO: validate the language object.
+    }
+
+    /**
      * Sets the post localization data.
      *
-     * @param array $i18n_data The polylang data in an associative array.
+     * @deprecated
+     *
+     * @param array $i18n_data The localization data in an associative array.
      */
     public function set_i18n( $i18n_data ) {
         $this->i18n = $i18n_data;
         $this->validate_i18n( $this->i18n );
+
+        $locale = Util::get_prop( $this->i18n, 'locale' );
+        $master = Util::get_prop( $this->i18n, 'master' );
+
+        if ( ! is_scalar( $master ) ) {
+            $master = Util::get_prop( $master, 'query_key' );
+        }
+
+        $this->language = new Language( $locale, $master );
     }
 
     /**
@@ -588,9 +655,7 @@ class Post {
             $this->set_error( 'i18n', $i18n, $err );
         }
         elseif ( ! in_array( Util::get_prop( $i18n, 'locale' ), Polylang::language_list(), true ) ) {
-            // @codingStandardsIgnoreStart
-            $err = __( 'Error in the polylang data. The locale doesn\'t exist in the current WP installation', 'oopi' );
-            // @codingStandardsIgnoreEnd
+            $err = __( 'Error in the polylang data. The locale doesn\'t exist in the current WP installation', 'oopi' ); // phpcs:ignore
             $this->set_error( 'i18n', $i18n, $err );
         }
 
@@ -673,7 +738,7 @@ class Post {
         }
 
         // Save localization data.
-        if ( ! empty( $this->i18n ) ) {
+        if ( ! empty( $this->language ) ) {
             Localization\Controller::save_language( $this );
         }
 
@@ -1056,38 +1121,31 @@ class Post {
     protected function save_taxonomies() {
         if ( is_array( $this->taxonomies ) ) {
             $term_ids_by_tax = [];
-            foreach ( $this->taxonomies as $term_data ) {
-                if ( $term_data instanceof \WP_Term ) {
-                    $term_obj = $term_data;
-                    $taxonomy = $term_obj->taxonomy;
-                }
-                else {
-                    // Safely get values from the term.
-                    $slug     = Util::get_prop( $term_data, 'slug' );
-                    $taxonomy = Util::get_prop( $term_data, 'taxonomy' );
-
-                    // Fetch the term object.
-                    $term_obj = Storage::get_term_by_slug( $slug, $taxonomy );
-                }
+            foreach ( $this->taxonomies as $term ) {
+                $taxonomy = $term->get_taxonomy();
+                $wp_term  = $term->get_term();
 
                 // If the term does not exist, create it.
-                if ( ! $term_obj ) {
-                    $term_obj = Storage::create_new_term( (array) $term_data, $this );
-                    if ( is_wp_error( $term_obj ) ) {
+                if ( ! $wp_term ) {
+                    $wp_term = Storage::create_new_term( $term, $this );
+                    if ( is_wp_error( $wp_term ) ) {
                         // Skip erroneous terms.
                         continue;
                     }
                 }
 
+                // Ensure identification. Data is only set once.
+                $term->identify();
+
                 // Handle localization.
-                Localization\Controller::set_term_language( $term_obj->term_id, $this );
+                Localization\Controller::set_term_language( $term, $this );
 
                 // Add term id.
                 if ( isset( $term_ids_by_tax[ $taxonomy ] ) ) {
-                    $term_ids_by_tax[ $taxonomy ][] = $term_obj->term_id;
+                    $term_ids_by_tax[ $taxonomy ][] = $wp_term->term_id;
                 }
                 else {
-                    $term_ids_by_tax[ $taxonomy ] = [ $term_obj->term_id ];
+                    $term_ids_by_tax[ $taxonomy ] = [ $wp_term->term_id ];
                 }
             }
             foreach ( $term_ids_by_tax as $taxonomy => $terms ) {

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -23,7 +23,13 @@ class Storage {
      * @return string
      */
     public static function format_query_key( $oopi_id ) {
-        return Settings::get( 'id_prefix' ) . $oopi_id;
+        $id_prefix = Settings::get( 'id_prefix' );
+
+        if ( strpos( $oopi_id, $id_prefix ) !== 0 ) {
+            return Settings::get( 'id_prefix' ) . $oopi_id;
+        }
+
+        return $oopi_id;
     }
 
     /**
@@ -41,7 +47,7 @@ class Storage {
     /**
      * Query the WP post id by the given Oopi id.
      *
-     * @param  int|string $id The api id to be matched with postmeta.
+     * @param  int|string $id The Oopi id to be matched with postmeta.
      * @return int|boolean The found post id or 'false' for empty results.
      */
     public static function get_post_id_by_oopi_id( $id ) {
@@ -52,6 +58,31 @@ class Storage {
         $prepared = $wpdb->prepare(
             "SELECT DISTINCT post_id FROM $wpdb->postmeta WHERE meta_key = %s",
             $post_meta_key
+        );
+        // Fetch results from the postmeta table.
+        $results = $wpdb->get_col( $prepared ); // phpcs:ignore
+
+        if ( ! empty( $results ) ) {
+            return (int) $results[0];
+        }
+
+        return false;
+    }
+
+    /**
+     * Query the WP term id by the given Oopi id.
+     *
+     * @param  int|string $id The Oopi id to be matched with termmeta.
+     * @return int|boolean The found term id or 'false' for empty results.
+     */
+    public static function get_term_id_by_oopi_id( $id ) {
+        global $wpdb;
+        // Concatenate the meta key.
+        $term_meta_key = static::format_query_key( $id );
+        // Prepare the sql.
+        $prepared = $wpdb->prepare(
+            "SELECT DISTINCT term_id FROM $wpdb->termmeta WHERE meta_key = %s",
+            $term_meta_key
         );
         // Fetch results from the postmeta table.
         $results = $wpdb->get_col( $prepared ); // phpcs:ignore
@@ -173,18 +204,21 @@ class Storage {
     /**
      * Create a new term.
      *
-     * @param  array $term Term data.
-     * @param  Post  $post The current Oopi post instance.
+     * @param  Term $term Term data.
+     * @param  Post $post The current Oopi post instance.
      *
      * @return object|\WP_Error An array containing the `term_id` and `term_taxonomy_id`,
      *                        WP_Error otherwise.
      */
-    public static function create_new_term( array $term, Post $post ) {
+    public static function create_new_term( Term $term, Post $post ) {
         $taxonomy = $term['taxonomy'] ?? '';
         $name     = $term['name'] ?? '';
         $slug     = $term['slug'] ?? '';
-        // There might be a parent set.
-        $parent = isset( $term['parent'] ) ? get_term_by( 'slug', $term['parent'], $taxonomy ) : false;
+
+        // If parent's Oopi id is set, fetch it. Default to 0.
+        $parent    = $term->get_parent();
+        $parent_id = $parent ? static::get_term_id_by_oopi_id( $parent ) : 0;
+
         // Insert the new term.
         $result = wp_insert_term(
             $name,
@@ -192,7 +226,7 @@ class Storage {
             [
                 'slug'        => $slug,
                 'description' => isset( $term['description'] ) ? $term['description'] : '',
-                'parent'      => $parent ? $parent->term_id : 0,
+                'parent'      => $parent_id,
             ]
         );
         // Something went wrong.
@@ -201,6 +235,11 @@ class Storage {
             $post->set_error( 'taxonomy', $name, $err );
             return $result;
         }
+
+        // Identify the Oopi term.
+        $wp_term = get_term( $result['term_id'] );
+        $term->set_term( $wp_term );
+        $term->identify();
 
         return (object) $result;
     }

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -207,32 +207,28 @@ class Storage {
      * @param  Term $term Term data.
      * @param  Post $post The current Oopi post instance.
      *
-     * @return object|\WP_Error An array containing the `term_id` and `term_taxonomy_id`,
+     * @return array|\WP_Error An array containing the `term_id` and `term_taxonomy_id`,
      *                        WP_Error otherwise.
      */
     public static function create_new_term( Term $term, Post $post ) {
-        $taxonomy = $term['taxonomy'] ?? '';
-        $name     = $term['name'] ?? '';
-        $slug     = $term['slug'] ?? '';
-
         // If parent's Oopi id is set, fetch it. Default to 0.
         $parent    = $term->get_parent();
         $parent_id = $parent ? static::get_term_id_by_oopi_id( $parent ) : 0;
 
         // Insert the new term.
         $result = wp_insert_term(
-            $name,
-            $taxonomy,
+            $term->get_name(),
+            $term->get_taxonomy(),
             [
-                'slug'        => $slug,
-                'description' => isset( $term['description'] ) ? $term['description'] : '',
+                'slug'        => $term->get_slug(),
+                'description' => $term->get_description(),
                 'parent'      => $parent_id,
             ]
         );
         // Something went wrong.
         if ( is_wp_error( $result ) ) {
             $err = __( 'An error occurred creating the taxonomy term.', 'oopi' );
-            $post->set_error( 'taxonomy', $name, $err );
+            $post->set_error( 'taxonomy', $term->get_name(), $err );
             return $result;
         }
 
@@ -241,6 +237,6 @@ class Storage {
         $term->set_term( $wp_term );
         $term->identify();
 
-        return (object) $result;
+        return $result;
     }
 }

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -148,7 +148,7 @@ class Storage {
      * Create a new term.
      *
      * @param  array $term Term data.
-     * @param  Post  $post The current post instance.
+     * @param  Post  $post The current Oopi post instance.
      *
      * @return object|\WP_Error An array containing the `term_id` and `term_taxonomy_id`,
      *                        WP_Error otherwise.
@@ -170,6 +170,12 @@ class Storage {
             $err = __( 'An error occurred creating the taxonomy term.', 'oopi' );
             $post->set_error( 'taxonomy', $name, $err );
             return $result;
+        }
+
+        // Handle localization.
+        $term_id = $result['term_id'] ?? false;
+        if ( $post->get_i18n() && $term_id ) {
+            Localization\Controller::set_term_language( $result['term_id'], $post );
         }
 
         return (object) $result;

--- a/src/Term.php
+++ b/src/Term.php
@@ -58,6 +58,13 @@ class Term {
     protected $taxonomy;
 
     /**
+     * The term description
+     *
+     * @var string
+     */
+    protected $description = '';
+
+    /**
      * The optional language data
      *
      * @var Language
@@ -90,6 +97,15 @@ class Term {
      */
     public function get_oopi_id() : string {
         return $this->oopi_id;
+    }
+
+    /**
+     * Get the WP term id.
+     *
+     * @return int
+     */
+    public function get_term_id() : int {
+        return $this->term->term_id ?? 0;
     }
 
     /**
@@ -196,6 +212,28 @@ class Term {
     public function set_taxonomy( ?string $taxonomy ) : Term {
 
         $this->taxonomy = $taxonomy;
+
+        return $this;
+    }
+
+    /**
+     * Get the description.
+     *
+     * @return string
+     */
+    public function get_description(): string {
+        return $this->description;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param string $description The description.
+     *
+     * @return Term Return self to enable chaining.
+     */
+    public function set_description( ?string $description ): Term {
+        $this->description = $description;
 
         return $this;
     }

--- a/src/Term.php
+++ b/src/Term.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * The Term class is used to import terms into WordPress.
+ */
+
+namespace Geniem\Oopi;
+
+use Geniem\Oopi\Traits\PropertyBinder;
+use WP_Term;
+
+/**
+ * Class Term
+ *
+ * Handles term importing.
+ *
+ * @package Geniem\Oopi
+ */
+class Term {
+
+    /**
+     * Add the set_data() binding method.
+     */
+    use PropertyBinder;
+
+    /**
+     * A unique id for external identification.
+     *
+     * @var string
+     */
+    protected $oopi_id;
+
+    /**
+     * If this is an existing term, the term is loaded here.
+     *
+     * @var WP_Term
+     */
+    protected $term;
+
+    /**
+     * The term slug.
+     *
+     * @var string
+     */
+    protected $slug;
+
+    /**
+     * The display name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The WP taxonomy slug.
+     *
+     * @var string
+     */
+    protected $taxonomy;
+
+    /**
+     * The optional language data
+     *
+     * @var Language
+     */
+    protected $language;
+
+    /**
+     * An Oopi id of the parent term.
+     *
+     * @var string
+     */
+    protected $parent;
+
+    /**
+     * Term constructor.
+     *
+     * @param string       $oopi_id A term must always contain an external id.
+     * @param WP_Term|null $term If a WP Term is set, the imported data
+     *                           will override data in the term.
+     */
+    public function __construct( $oopi_id, ?WP_Term $term = null ) {
+        $this->oopi_id = $oopi_id;
+        $this->term    = $term;
+    }
+
+    /**
+     * Get the oopi id.
+     *
+     * @return string
+     */
+    public function get_oopi_id() : string {
+        return $this->oopi_id;
+    }
+
+    /**
+     * Get the term.
+     *
+     * @return WP_Term
+     */
+    public function get_term() : ?WP_Term {
+        if ( empty( $this->term ) ) {
+            $term_id    = Storage::get_term_id_by_oopi_id( $this->get_oopi_id() );
+            $this->term = get_term( $term_id );
+        }
+
+        // If no term is found with the Oopi id, try to find by slug.
+        if ( ! $this->term instanceof WP_Term ) {
+            // Fetch the WP term object.
+            $this->term = Storage::get_term_by_slug( $this->get_slug(), $this->get_taxonomy() );
+        }
+
+        return $this->term;
+    }
+
+    /**
+     * Set the term.
+     *
+     * @param WP_Term $term A WP term object.
+     *
+     * @return Term Return self to enable chaining.
+     */
+    public function set_term( ?WP_Term $term ) : Term {
+        $this->term = $term;
+
+        // Set properties with WP term data.
+        $this->set_data( $term );
+
+        return $this;
+    }
+
+    /**
+     * Get the slug.
+     *
+     * @return string
+     */
+    public function get_slug() : string {
+
+        return $this->slug;
+    }
+
+    /**
+     * Set the slug.
+     *
+     * @param string $slug The slug.
+     *
+     * @return Term Return self to enable chaining.
+     */
+    public function set_slug( ?string $slug ) : Term {
+
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    /**
+     * Get the display name.
+     *
+     * @return string
+     */
+    public function get_name() : string {
+
+        return $this->name;
+    }
+
+    /**
+     * Set the display name.
+     *
+     * @param string $name The name.
+     *
+     * @return Term Return self to enable chaining.
+     */
+    public function set_name( ?string $name ) : Term {
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get the taxonomy.
+     *
+     * @return string
+     */
+    public function get_taxonomy() : string {
+
+        return $this->taxonomy;
+    }
+
+    /**
+     * Set the taxonomy slug.
+     *
+     * @param string $taxonomy The WP taxonomy slug.
+     *
+     * @return Term Return self to enable chaining.
+     */
+    public function set_taxonomy( ?string $taxonomy ) : Term {
+
+        $this->taxonomy = $taxonomy;
+
+        return $this;
+    }
+
+    /**
+     * Get the language.
+     *
+     * @return Language
+     */
+    public function get_language() : Language {
+        return $this->language;
+    }
+
+    /**
+     * Set the language.
+     *
+     * @param Language $language The language.
+     *
+     * @return Term Return self to enable chaining.
+     */
+    public function set_language( ?Language $language ) : Term {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    /**
+     * Get the parent term Oopi id.
+     *
+     * @return string|null
+     */
+    public function get_parent() : ?string {
+        return $this->parent;
+    }
+
+    /**
+     * Set the parent term Oopi id.
+     *
+     * @param string|null $parent The parent id.
+     *
+     * @return Term Return self to enable chaining.
+     */
+    public function set_parent( ?string $parent ) : Term {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * Adds term meta rows for matching a WP term with an external source.
+     */
+    public function identify() {
+        $id_prefix = Settings::get( 'id_prefix' );
+
+        // Remove the trailing '_'.
+        $identificator = rtrim( $id_prefix, '_' );
+
+        // Set the queryable identificator.
+        // Example: meta_key = 'oopi_id', meta_value = 12345
+        add_term_meta( $this->term->term_id, $identificator, $this->oopi_id, true );
+
+        // Set the indexed indentificator.
+        // Example: meta_key = 'oopi_id_12345', meta_value = 12345
+        add_term_meta( $this->term->term_id, $id_prefix . $this->oopi_id, $this->oopi_id, true );
+    }
+}

--- a/src/Traits/PropertyBinder.php
+++ b/src/Traits/PropertyBinder.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Contains a helper method for binding data into objects.
+ */
+
+namespace Geniem\Oopi\Traits;
+
+/**
+ * Trait PropertyBinder
+ */
+trait PropertyBinder {
+
+    /**
+     * A helper method for adding all data with a single call.
+     *
+     * @param array|object $data The term data.
+     * @return self
+     */
+    public function set_data( $data ) : self {
+        foreach ( (array) $data as $key => $value ) {
+            if ( $key === 'oopi_id' ) {
+                // Not allowed after instantiation.
+                continue;
+            }
+
+            // Validate if a validation method exists.
+            $valid = method_exists( $this, "validate_$key" ) ?
+                call_user_func( [ $this, "validate_$key" ] ) : true;
+
+            if ( property_exists( $this, $key ) && $valid ) {
+                $this->{$key} = $value;
+            }
+        }
+
+        return $this;
+    }
+
+}


### PR DESCRIPTION
### Added
- New typed classes for taxonomy term and language data.
  - Geniem\Oopi\Term
  - Geniem\Oopi\Language
- Localize newly created terms if language data is added for the Post object.
- Try to prevent the post name from getting a number suffix
  when translating posts with Polylang by updating the post data
  with the original post name after setting the language.
- Add a language agnostic term finding method to Storage class. Use it to find terms by slug.

### Changed
- Allow language data to be set as an associative array or an object. Map data into a Geniem\Oopi\Language object.
- Simplify Oopi id handling in get_post_id_by_oopi_id().
- The `i18n` is now deprecated, but still functioning if set. The data is mapped into a Geniem\Oopi\Language object.
- Taxonomy term data must contain an `oopi_id` for identification.