### PR TITLE
Log cleanup cronjob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Schedule log cleaner cronjob on plugin activation. The cronjob deletes all rows with OK status by ID except the lastest one.
+
 ## [Released]
 
 ## [1.0.0] - 2020-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Schedule log cleaner cronjob on plugin activation. The cronjob deletes all rows with OK status by ID except the lastest one.
+- Schedule log cleaner cronjob on plugin activation. The cronjob deletes all rows with OK status by ID except the latest one.
 
 ## [Released]
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The `\Geniem\Oopi\Settings\` class is used to set and load all plugin settings. 
 - Setting key `table_name`, constant `OOPI_TABLE_NAME`, default value `geniem_importer_log`.
 - Setting key `log_status_ok`, constant `OOPI_LOG_STATUS_OK`, default value `'OK'`.
 - Setting key `log_status_fail`, constant `OOPI_LOG_STATUS_FAIL`, default value `'FAIL'`.
+- Setting key `cron_interval_clean_log`, constant `OOPI_CRON_INTERVAL_CLEAN_LOG`, default `'daily'`.
 
 ### Accessing settings
 
@@ -187,6 +188,12 @@ The plugin creates a custom table into the WordPress database called `oopi_log`.
 The log provides a rollback feature. If an import fails the importer tries to roll back the previous successful import. If no previous imports with the `OK` status are found, the imported object is set into `draft` state to prevent front-end users from accessing posts with malformed data.
 
 To disable the rollback feature set the `OOPI_ROLLBACK_DISABLE` constant with a value of `true`.
+
+### Log cleanup
+
+The plugin registers a log cleaner cronjob on plugin activation. The cronjob deletes all rows with OK status by `wp_id` except the latest one. This enables keeping the log table clean while maintaining full support for rollback feature.
+
+The cronjob is run with `'daily'` interval by default, it can be changed with `OOPI_CRON_INTERVAL_CLEAN_LOG` constant. Cronjob scheduling can be disabled by defining the constant as `false`.
 
 ## Tests
 

--- a/plugin.php
+++ b/plugin.php
@@ -51,11 +51,23 @@ class Plugin {
     ];
 
     /**
-     * Create required database tables on install.
+     * Run tasks when plugin is activated.
      */
     public static function install() {
         // Install log handler.
         Log::install();
+
+        // Register cron jobs.
+        CronJobs::install();
+    }
+
+
+    /**
+     * Run tasks when plugin is deactivated.
+     */
+    public static function uninstall() {
+        // Remove cron jobs.
+        CronJobs::uninstall();
     }
 
     /**
@@ -78,6 +90,9 @@ class Plugin {
 
         // Initialize the import handlers for importables.
         self::set_initial_import_handlers();
+
+        // Register the cron job hooks.
+        CronJobs::init();
 
         // Initialize plugin controllers after plugins are loaded.
         add_action( 'wp_loaded', function() {
@@ -144,4 +159,7 @@ class Plugin {
 Plugin::init();
 
 // Run installation on activation hook.
-register_activation_hook( __FILE__, [ Plugin::class, 'install' ] );
+\register_activation_hook( __FILE__, [ Plugin::class, 'install' ] );
+
+// Run uninstallation on deactivation hook.
+\register_deactivation_hook( __FILE__, [ Plugin::class, 'uninstall' ] );

--- a/src/CronJobs.php
+++ b/src/CronJobs.php
@@ -60,7 +60,6 @@ class CronJobs {
                 continue;
             }
 
-            \error_log( 'setting OOPI hook' );
             \add_action( $job::HOOK, [ $job, 'run' ] );
         }
     }
@@ -80,8 +79,7 @@ class CronJobs {
             }
 
             if ( ! \wp_next_scheduled( $job::HOOK ) ) {
-                \error_log( 'scheduled OOPI cron event' );
-                \wp_schedule_event( \time(), $interval, $job::HOOK );
+                \wp_schedule_event( time(), $interval, $job::HOOK );
             }
         }
     }

--- a/src/CronJobs.php
+++ b/src/CronJobs.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * The CronJobs class file.
+ */
+
+namespace Geniem\Oopi;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Class CronJobs
+ *
+ * This class controls cron jobs the plugin registers.
+ *
+ * @package Geniem\Oopi
+ */
+class CronJobs {
+
+    /**
+     * Register cron jobs.
+     *
+     * @return void
+     */
+    public static function install() : void {
+        static::schedule_cronjobs();
+    }
+
+    /**
+     * Terminate cron jobs.
+     *
+     * @return void
+     */
+    public static function uninstall() : void {
+        static::unschedule_cronjobs();
+    }
+
+    /**
+     * Return the cronjobs.
+     *
+     * @return array
+     */
+    public static function get_cronjobs() : array {
+        return [
+            LogCleaner::class,
+        ];
+    }
+
+    /**
+     * Register the hooks to fire when cron is run.
+     *
+     * @return void
+     */
+    public static function init() : void {
+        $cronjobs = static::get_cronjobs();
+        foreach ( $cronjobs as $job ) {
+
+            if ( ! \method_exists( $job, 'run' ) ) {
+                continue;
+            }
+
+            \error_log( 'setting OOPI hook' );
+            \add_action( $job::HOOK, [ $job, 'run' ] );
+        }
+    }
+
+    /**
+     * Schedule all cronjobs.
+     *
+     * @return void
+     */
+    public static function schedule_cronjobs() : void {
+        $cronjobs = static::get_cronjobs();
+        foreach ( $cronjobs as $job ) {
+            $key       = $job::KEY;
+            $interval  = Settings::get( "cron_interval_$key" );
+            if ( false === $interval ) {
+                continue;
+            }
+
+            if ( ! \wp_next_scheduled( $job::HOOK ) ) {
+                \error_log( 'scheduled OOPI cron event' );
+                \wp_schedule_event( \time(), $interval, $job::HOOK );
+            }
+        }
+    }
+
+    /**
+     * Unschedule all cronjobs.
+     *
+     * @return void
+     */
+    public static function unschedule_cronjobs() : void {
+        $cronjobs = static::get_cronjobs();
+        foreach ( $cronjobs as $job ) {
+            $timestamp = \wp_next_scheduled( $job::HOOK );
+            if ( $timestamp ) {
+                \wp_unschedule_event( $timestamp, $job::HOOK );
+            }
+        }
+    }
+}

--- a/src/CronJobs.php
+++ b/src/CronJobs.php
@@ -73,7 +73,7 @@ class CronJobs {
         $cronjobs = static::get_cronjobs();
         foreach ( $cronjobs as $job ) {
             $key       = $job::KEY;
-            $interval  = Settings::get( "cron_interval_$key" );
+            $interval  = Settings::get( "cron_interval_{$key}" );
             if ( false === $interval ) {
                 continue;
             }

--- a/src/LogCleaner.php
+++ b/src/LogCleaner.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * The LogCleaner class file.
+ */
+
+namespace Geniem\Oopi;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Class LogCleaner
+ *
+ * This class controls cleaning the log database table.
+ *
+ * @package Geniem\Oopi
+ */
+class LogCleaner {
+
+    /**
+     * The key used for this cron job.
+     */
+    const KEY = 'clean_log';
+
+    /**
+     * The hook used for this cron job.
+     */
+    const HOOK = 'oopi_cron_clean_log';
+    
+    /**
+     * This handles cleaning the log table.
+     *
+     * This deletes all rows with OK status by ID except the latest one.
+     * This enables keeping the log table clean while maintaining the
+     * ability to rollback individual posts.
+     *
+     * @return void
+     */
+    public static function run() : void {
+        \error_log( 'Running cron' );
+        global $wpdb;
+
+        $table_name = Log::get_table_name();
+        $ok_status  = Settings::get( 'log_status_ok' );
+        $query      = $wpdb->prepare(
+            "
+            DELETE wlo1.*
+            FROM $table_name wlo1
+            JOIN (
+                SELECT 
+                    wp_id,
+                    COALESCE(
+                        (
+                            SELECT import_date_gmt
+                            FROM $table_name wlo2
+                            WHERE wlo2.wp_id = wlo4.wp_id
+                                AND wlo2.status = %s
+                            ORDER BY
+                                wlo2.wp_id DESC, wlo2.import_date_gmt DESC
+                            LIMIT 1, 1
+                        ),
+                        CAST('0001-01-01' AS DATETIME)
+                    ) AS mts,
+                    COALESCE(
+                        (
+                            SELECT id
+                            FROM $table_name wlo2
+                            WHERE wlo2.wp_id = wlo4.wp_id
+                                AND wlo2.status = %s
+                            ORDER BY
+                                wlo2.wp_id DESC, wlo2.import_date_gmt DESC, wlo2.id DESC
+                            LIMIT 1, 1
+                        ),
+                        -1
+                    ) AS mid
+                FROM (
+                    SELECT DISTINCT wp_id
+                    FROM $table_name wlo3
+                ) wlo4
+            ) wlo3
+            ON wlo1.wp_id = wlo3.wp_id
+            AND (wlo1.import_date_gmt, wlo1.id) <= (mts, mid)
+            WHERE wlo1.status = %s
+            ",
+            [
+                $ok_status,
+                $ok_status,
+                $ok_status,
+            ]
+        );
+
+        $wpdb->query( $query );
+
+        \error_log( 'OOPI log table cleaned' );
+    }
+}

--- a/src/LogCleaner.php
+++ b/src/LogCleaner.php
@@ -38,7 +38,6 @@ class LogCleaner {
      * @return void
      */
     public static function run() : void {
-        \error_log( 'Running cron' );
         global $wpdb;
 
         $table_name = Log::get_table_name();
@@ -91,7 +90,5 @@ class LogCleaner {
         );
 
         $wpdb->query( $query );
-
-        \error_log( 'OOPI log table cleaned' );
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -39,6 +39,7 @@ class Settings {
         self::set( 'TMP_FOLDER', '/tmp/' );
         self::set( 'LOG_STATUS_OK', 'OK' );
         self::set( 'LOG_STATUS_FAIL', 'FAIL' );
+        self::set( 'CRON_INTERVAL_CLEAN_LOG', 'daily' );
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,18 +1,15 @@
 <?php
 /**
- * Bootsrtap PHPUnit tests.
+ * Bootstrap PHPUnit tests.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/../' );
 }
 
-function define_constanst() {
-    if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
-        define( 'HOUR_IN_SECONDS', 60 * 60 * 60 );
-    }
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 60 * 60 * 60 );
 }
-define_constanst();
 
 /**
  * Define mocks for WP functionalities.
@@ -35,7 +32,15 @@ function wp_mocks() {
     // Mock the plugin activation hook.
     WP_Mock::userFunction( 'register_activation_hook',
         [
-            // Nothig to do with the result.
+            // Nothing to do with the result.
+            'return' => true,
+        ]
+    );
+
+    // Mock the plugin deactivation hook.
+    WP_Mock::userFunction( 'register_deactivation_hook',
+        [
+            // Nothing to do with the result.
             'return' => true,
         ]
     );
@@ -43,11 +48,11 @@ function wp_mocks() {
     // Mock an anonymous object to mock category as a registered taxonomy.
     $category = Mockery::mock();
     $category->shouldReceive( 'get_taxonomy' )
+        ->set( 'name', 'Test' )
+        ->set( 'slug', 'test' )
+        ->set( 'description', '' )
+        ->set( 'taxonomy', 'category' )
         ->andReturn( 'category' );
-    $category->name = 'Test';
-    $category->slug = 'test';
-    $category->description = '';
-    $category->taxonomy = 'category';
 
     WP_Mock::userFunction( 'get_taxonomies', [
         'return' => [


### PR DESCRIPTION
The MySQL query cleaning the table is quite complicated, but it allows maintaning full rollback support by removing all but the newest `OK` entry from the log versus simply removing all rows older that X days.

The cronjob assumes the log table is using the new DB structure from `1.0.0` update (`post_id` column renamed to `wp_id` in log table).

As a note however, the plugin does not include a migration to make that change, so basically the cronjob only works if

* the site has installed `1.0.0` without having an earlier version
* the column name is changed manually (for pre-1.0.0 version)
* the log table is deleted manually and plugin is re-activated (pre-1.0.0 versions).