### PR TITLE
Remove query params from image file name

### DIFF
--- a/src/Importer/AttachmentImporter.php
+++ b/src/Importer/AttachmentImporter.php
@@ -225,8 +225,9 @@ class AttachmentImporter implements Importer {
             ] );
         }
 
-        // Get filename from the url.
-        $file_name = basename( $attachment_src );
+        // Get filename from the url and remove query params.
+        $file_name = basename( parse_url( $attachment_src, PHP_URL_PATH ) );
+
         // Exif related variables
         $exif_imagetype            = exif_imagetype( $attachment_src );
         $exif_supported_imagetypes = [


### PR DESCRIPTION
If image url has get parameters the parameter will be part of the file name.