### PR TITLE
Fixed ignore ssl strip_unsupported_exif_data()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Fixed the issue https://github.com/devgeniem/wp-oopi/issues/23 If OOPI_IGNORE_SSL has been enabled and the certificate on the source site is invalid, the exif_imagetype() function cannot be used in the AttachmentImporter.
+
 ### Changed
 
 - Enabled PHP 8.0 and PHP 8.1 usage #18

--- a/src/Importer/AttachmentImporter.php
+++ b/src/Importer/AttachmentImporter.php
@@ -238,11 +238,15 @@ class AttachmentImporter implements Importer {
 
         // If SSL is ignored we need to use different methods to check file extension from the source file.
         // Always prefer to use SSL.
-        if ( defined( 'OOPI_IGNORE_SSL' ) && OOPI_IGNORE_SSL ) {
+        if (
+            defined( 'OOPI_IGNORE_SSL' ) &&
+            OOPI_IGNORE_SSL &&
+            is_callable( 'exif_read_data' )
+        ) {
 
             $this->strip_exif_by_file_extension( $local_image, $attachment_src, $error_handler );
         }
-        else {
+        elseif ( is_callable( 'exif_read_data' ) ) {
 
             $this->strip_exif_by_exif_data( $local_image, $attachment_src, $error_handler );
         }
@@ -308,10 +312,8 @@ class AttachmentImporter implements Importer {
         }
 
         // If exif_read_data is callable and file type could contain exif data.
-        if (
-            is_callable( 'exif_read_data' ) &&
-            in_array( $exif_imagetype, $exif_supported_imagetypes, true )
-        ) {
+        if ( in_array( $exif_imagetype, $exif_supported_imagetypes, true ) ) {
+
             // Manipulate image exif data.
             $this->strip_unsupported_exif_data( $local_image, $error_handler );
         }
@@ -361,10 +363,8 @@ class AttachmentImporter implements Importer {
         ];
 
         // If exif_read_data is callable and file type could contain exif data.
-        if (
-            is_callable( 'exif_read_data' ) &&
-            in_array( $file_extension, $exif_supported_file_extensions, true )
-        ) {
+        if ( in_array( $file_extension, $exif_supported_file_extensions, true ) ) {
+
             // Manipulate image exif data.
             $this->strip_unsupported_exif_data( $local_image, $error_handler );
         }


### PR DESCRIPTION
- Fixed the issue https://github.com/devgeniem/wp-oopi/issues/23 If OOPI_IGNORE_SSL has been enabled and the certificate on the source site is invalid, the exif_imagetype() function cannot be used in the AttachmentImporter.