### PR TITLE
Fix calling json_decode with non-string input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
+## [Released]
 
+## [1.3.1] - 2024-01-29
+
+### Changed
 - Enabled PHP 8.0 and PHP 8.1 usage #18
 
-## [Released]
+### Fixed
+- Fix PHP 8 deprecation.
 
 ## [1.3.0] - 2023-08-01
 - Fixed the issue https://github.com/devgeniem/wp-oopi/issues/23 If OOPI_IGNORE_SSL has been enabled and the certificate on the source site is invalid, the exif_imagetype() function cannot be used in the AttachmentImporter.

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Oopi
  * Plugin URI:  https://github.com/devgeniem/wp-oopi
  * Description: Oopi is an object-oriented developer friendly WordPress importer.
- * Version:     1.3.0
+ * Version:     1.3.1
  * Author:      Geniem
  * Author URI:  http://www.github.com/devgeniem
  * License:     GPL3

--- a/src/Util.php
+++ b/src/Util.php
@@ -22,6 +22,10 @@ class Util {
      */
     public static function is_json( $data ) {
 
+        if ( ! is_string( $data ) ) {
+            return false;
+        }
+
         json_decode( $data );
 
         return ( json_last_error() === JSON_ERROR_NONE );


### PR DESCRIPTION
```
PHP Deprecated:  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in wp-oopi/src/Util.php on line 25"
```

`json_decode` expects the first parameter to be a string, so let's just return false if the input is not a string.