### PR TITLE
Fix docblock in AttachmentImportable

### DIFF
--- a/src/Importable/AttachmentImportable.php
+++ b/src/Importable/AttachmentImportable.php
@@ -300,7 +300,7 @@ class AttachmentImportable implements Importable {
     /**
      * Set the parent's WP id for the attachment.
      *
-     * @param int|null $parent_wp_id The parent WP id.
+     * @param int $parent_wp_id The parent WP id.
      *
      * @return AttachmentImportable Return self to enable chaining.
      */


### PR DESCRIPTION
`$parent_wp_id` is always an integer.
