### PR TITLE
Change return type of get_value() to mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Released]
 
+## [1.4.1] - 2024-10-10
+
+### Fixed
+- Change return type of get_value() to mixed #37
+
 ## [1.4.0] - 2024-05-08
 
 ### Changed

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Oopi
  * Plugin URI:  https://github.com/devgeniem/wp-oopi
  * Description: Oopi is an object-oriented developer friendly WordPress importer.
- * Version:     1.4.0
+ * Version:     1.4.1
  * Author:      Geniem
  * Author URI:  http://www.github.com/devgeniem
  * License:     GPL3

--- a/src/Attribute/Meta.php
+++ b/src/Attribute/Meta.php
@@ -69,9 +69,9 @@ abstract class Meta implements Attribute {
     /**
      * Get the value.
      *
-     * @return string
+     * @return mixed
      */
-    public function get_value(): string {
+    public function get_value() {
         return $this->value;
     }
 


### PR DESCRIPTION
The previous return type was too restrictive, as the method could potentially return other types of values.